### PR TITLE
Pattern.simplify() (#9)

### DIFF
--- a/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/AlternativeExploder.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/AlternativeExploder.php
@@ -1,0 +1,35 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+
+class AlternativeExploder
+{
+    public function explode(array $models): array
+    {
+        return $this->flatten($this->explodeModels($models));
+    }
+
+    private function explodeModels(array $inside): array
+    {
+        return array_map(function (Model $model) {
+            if ($model instanceof Literal) {
+                return $model->explodeByAlternative();
+            }
+            return [$model];
+        }, $inside);
+    }
+
+    private function flatten(array $array): array
+    {
+        $count = count($array);
+        if ($count === 0) {
+            return [];
+        }
+        if ($count === 1) {
+            return reset($array);
+        }
+        return call_user_func_array('array_merge', $array);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/AlternativeGrouper.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/AlternativeGrouper.php
@@ -1,0 +1,17 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+
+class AlternativeGrouper
+{
+    /**
+     * @param Model[] $models
+     * @return Model[]
+     */
+    public function getGrouped(array $models): array
+    {
+        $split = (new LiteralAltSplitter($models))->split();
+        return (new LiteralAltJoiner($split))->join();
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltJoiner.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltJoiner.php
@@ -1,0 +1,98 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Alt;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltEnd;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltStart;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Analyze\Simplify\ModelList;
+use TRegx\CleanRegex\Exception\CleanRegex\InternalCleanRegexException;
+
+class LiteralAltJoiner
+{
+    /** @var Model[] */
+    private $models;
+
+    /** @var ModelList */
+    private $result;
+
+    /** @var ModelList */
+    private $buff;
+
+    /** @var AlternativeExploder */
+    private $exploder;
+
+    /** @var bool */
+    private $buffing = false;
+
+    public function __construct(array $models)
+    {
+        $this->models = $models;
+        $this->result = new ModelList();
+        $this->buff = new ModelList();
+        $this->exploder = new AlternativeExploder();
+    }
+
+    public function join(): array
+    {
+        foreach ($this->models as $model) {
+            if ($model instanceof AltStart) {
+                $this->alternativeStart($model);
+            }
+            else if ($model instanceof AltEnd) {
+                $this->alternativeEnd($model);
+            }
+            else {
+                $this->literals($model);
+            }
+        }
+        return $this->result->getAndClear();
+    }
+
+    private function alternativeStart(AltStart $alternative): void
+    {
+        if ($this->buffing) {
+            $this->result->addAll($this->buff->getAndClear());
+        }
+        else {
+            $this->buffing = true;
+        }
+        $this->buff->add($alternative);
+    }
+
+    private function alternativeEnd(AltEnd $alternative): void
+    {
+        if ($this->buffing) {
+            $this->buff->add($alternative);
+            $alt = $this->createAlt($this->buff->getAndClear());
+            $this->result->add($alt);
+            $this->buffing = false;
+        }
+        else {
+            $this->result->add($alternative);
+        }
+    }
+
+    private function createAlt(array $models): Alt
+    {
+        if (count($models) < 0) {
+            throw new InternalCleanRegexException();
+        }
+        return new Alt($this->exploder->explode($this->stripAltModels($models)));
+    }
+
+    private function stripAltModels(array $models): array
+    {
+        return array_slice($models, 1, -1);
+    }
+
+    private function literals(Model $model): void
+    {
+        if ($this->buffing) {
+            $this->buff->add($model);
+        }
+        else {
+            $this->result->add($model);
+        }
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltSplitter.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltSplitter.php
@@ -1,0 +1,61 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltEnd;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltStart;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Analyze\Simplify\ModelList;
+use TRegx\SafeRegex\preg;
+
+class LiteralAltSplitter
+{
+    /** @var Model[] */
+    private $models;
+
+    /** @var ModelList */
+    private $result;
+
+    public function __construct(array $models)
+    {
+        $this->models = $models;
+        $this->result = new ModelList();
+    }
+
+    public function split(): array
+    {
+        foreach ($this->models as $model) {
+            if ($model instanceof Literal) {
+                $elements = $this->transformLiteral($model);
+                $this->result->addAll($elements);
+            }
+            else {
+                $this->result->add($model);
+            }
+        }
+        return $this->result->getAndClear();
+    }
+
+    private function transformLiteral(Literal $model): array
+    {
+        return $this->createModels($this->splitContent($model->getContent()));
+    }
+
+    private function splitContent(string $content): array
+    {
+        return preg::split('/(\(\?:|\))/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+    }
+
+    private function createModels(array $elements): array
+    {
+        return array_map(function (string $string) {
+            if ($string === ')') {
+                return new AltEnd();
+            }
+            if ($string === '(?:') {
+                return new AltStart();
+            }
+            return new Literal($string);
+        }, $elements);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/CodePoint.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/CodePoint.php
@@ -1,0 +1,29 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+use InvalidArgumentException;
+
+class CodePoint
+{
+    /** @var string */
+    private $character;
+
+    public function __construct(string $character)
+    {
+        $this->character = $character;
+    }
+
+    public function index(): int
+    {
+        if (mb_strlen($this->character) !== 1) {
+            throw new InvalidArgumentException();
+        }
+        return $this->getCodePoint($this->character);
+    }
+
+    private function getCodePoint(string $string): int
+    {
+        $utf32 = mb_convert_encoding($string, 'UTF-32', 'UTF-8');
+        return hexdec(bin2hex($utf32));
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/LiteralLetters.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/LiteralLetters.php
@@ -1,0 +1,26 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+class LiteralLetters
+{
+    public function isLetterNotLiteral(string $character): bool
+    {
+        if (strlen($character) !== 1) {
+            return false;
+        }
+        return ctype_alpha($character) && !$this->isLiteral($character);
+    }
+
+    public function isLiteral(string $character): bool
+    {
+        return in_array($character, $this->getLiteralTokens());
+    }
+
+    private function getLiteralTokens(): array
+    {
+        return [
+            'F', 'I', 'J', 'M', 'O', 'T', 'Y',
+            'i', 'j', 'm', 'q', 'y'
+        ];
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Alt.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Alt.php
@@ -1,0 +1,64 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+class Alt extends Model
+{
+    /** @var Model[] */
+    private $models;
+
+    public function __construct(array $models)
+    {
+        $this->models = $models;
+    }
+
+    public function getContent(): string
+    {
+        if ($this->hasOnlySingleTokens()) {
+            return $this->getAsCharacterGroup();
+        }
+        return $this->getAsAlternative();
+    }
+
+    private function getAsCharacterGroup()
+    {
+        return '[' . join($this->getContentForCharacterGroup()) . ']';
+    }
+
+    private function getContentForCharacterGroup(): array
+    {
+        return array_map(function (Model $model) {
+            if ($model instanceof EscapedLiteral) {
+                return $model->getLiteralForCharacterGroup();
+            }
+            return $model->getContent();
+        }, $this->models);
+    }
+
+    private function getAsAlternative(): string
+    {
+        return '(?:' . join('|', $this->getModelContents()) . ')';
+    }
+
+    private function getModelContents(): array
+    {
+        return array_map(function (Model $model) {
+            return $model->getContent();
+        }, $this->models);
+    }
+
+    private function hasOnlySingleTokens()
+    {
+        $tokens = $this->getSingleTokens();
+        return count($tokens) === count($this->models);
+    }
+
+    /**
+     * @return Model[]
+     */
+    private function getSingleTokens(): array
+    {
+        return array_filter($this->models, function (Model $model) {
+            return $model->isSingleToken();
+        });
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/AltEnd.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/AltEnd.php
@@ -1,0 +1,18 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+class AltEnd extends Model
+{
+    /** @var string */
+    private $content;
+
+    public function __construct()
+    {
+        $this->content = ')';
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/AltStart.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/AltStart.php
@@ -1,0 +1,18 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+class AltStart extends Model
+{
+    /** @var string */
+    private $content;
+
+    public function __construct()
+    {
+        $this->content = '(?:';
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/EscapedLiteral.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/EscapedLiteral.php
@@ -1,0 +1,54 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+use TRegx\CleanRegex\Analyze\Simplify\LiteralLetters;
+
+class EscapedLiteral extends Model
+{
+    /** @var string */
+    private $escaped;
+
+    /** @var string[] */
+    const CHARACTER_LITERALS = ['"', "'", '\]', '#', ' '];
+
+    /** @var LiteralLetters */
+    private $literalTokens;
+
+    public function __construct(string $literal)
+    {
+        $this->escaped = $literal;
+        $this->literalTokens = new LiteralLetters();
+    }
+
+    public function getContent(): string
+    {
+        $unescaped = $this->escaped[1];
+        if ($this->isCharacterLiteral($unescaped) || $this->isLetterLiteral($unescaped)) {
+            return $unescaped;
+        }
+        return $this->escaped;
+    }
+
+    public function getLiteralForCharacterGroup(): string
+    {
+        if ($this->escaped[1] === ']') {
+            return '\\]';
+        }
+        return $this->escaped[1];
+    }
+
+    private function isCharacterLiteral(string $unescaped): bool
+    {
+        return in_array($unescaped, self::CHARACTER_LITERALS);
+    }
+
+    private function isLetterLiteral($unescaped): bool
+    {
+        return ctype_alpha($unescaped) && $this->literalTokens->isLiteral($unescaped);
+    }
+
+    public function isSingleToken(): bool
+    {
+        return true;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Group.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Group.php
@@ -1,0 +1,101 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+use TRegx\CleanRegex\Analyze\Simplify\LiteralLetters;
+use TRegx\CleanRegex\Analyze\Simplify\UnnecessaryGroupEscapes;
+use TRegx\CleanRegex\Exception\CleanRegex\InternalCleanRegexException;
+use TRegx\SafeRegex\preg;
+
+class Group extends Model
+{
+    /** @var string[] */
+    private $elements;
+
+    /** @var UnnecessaryGroupEscapes */
+    private $unnecessaryGroupEscapes;
+
+    /** @var LiteralLetters */
+    private $literalTokens;
+
+    public function __construct(array $group)
+    {
+        $this->elements = $group;
+        $this->literalTokens = new LiteralLetters();
+        $this->unnecessaryGroupEscapes = new UnnecessaryGroupEscapes($this->literalTokens, true);
+    }
+
+    public function getContent(): string
+    {
+        if (count($this->elements) === 0) {
+            throw new InternalCleanRegexException();
+        }
+        if (count($this->elements) === 1) {
+            /** @var string $element */
+            $element = $this->elements[0];
+
+            $groupNegatingToken = $this->asGroupNegatingToken($element);
+            if ($groupNegatingToken !== null) {
+                return $groupNegatingToken;
+            }
+
+            $token = $this->asCharactersToken($element);
+            if ($token !== null) {
+                return $token;
+            }
+        }
+        $group = $this->unnecessaryGroupEscapes->remove($this->elements);
+        return '[' . join($group) . ']';
+    }
+
+    private function asGroupNegatingToken(string $element): ?string
+    {
+        if (strlen($element) === 1) {
+            if ($element === ']') {
+                throw new InternalCleanRegexException();
+            }
+            return preg::quote($element);
+        }
+
+        if (strlen($element) === 2) {
+            return $this->unnecessaryGroupEscapes->remove([$element])[0];
+        }
+
+        return null;
+    }
+
+    private function asCharactersToken(string $value): ?string
+    {
+        $result = $this->getToken($value);
+        if ($result === null) {
+            return null;
+        }
+        if ($value[0] === '^') {
+            return strtoupper($result);
+        }
+        return $result;
+    }
+
+    private function getToken(string $value): ?string
+    {
+        $split = $this->splitTokenable($value);
+
+        if ($this->arraysEqual($split, ['0-9'])) {
+            return '\d';
+        }
+        if ($this->arraysEqual($split, ['a-z', 'A-Z', '0-9', '_'])) {
+            return '\w';
+        }
+        return null;
+    }
+
+    private function splitTokenable(string $value): array
+    {
+        preg::match_all('/(?:a\-z|0\-9|_)/i', $value, $elements);
+        return $elements[0];
+    }
+
+    private function arraysEqual(array $a, array $b): bool
+    {
+        return !array_diff($a, $b) && !array_diff($b, $a);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Group.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Group.php
@@ -2,6 +2,7 @@
 namespace TRegx\CleanRegex\Analyze\Simplify\Model;
 
 use TRegx\CleanRegex\Analyze\Simplify\LiteralLetters;
+use TRegx\CleanRegex\Analyze\Simplify\Posix\PosixClassSimplifier;
 use TRegx\CleanRegex\Analyze\Simplify\UnnecessaryGroupEscapes;
 use TRegx\CleanRegex\Exception\CleanRegex\InternalCleanRegexException;
 use TRegx\SafeRegex\preg;
@@ -43,7 +44,7 @@ class Group extends Model
                 return $token;
             }
         }
-        $group = $this->unnecessaryGroupEscapes->remove($this->elements);
+        $group = $this->removeEscapesAndDuplicates();
         return '[' . join($group) . ']';
     }
 
@@ -97,5 +98,16 @@ class Group extends Model
     private function arraysEqual(array $a, array $b): bool
     {
         return !array_diff($a, $b) && !array_diff($b, $a);
+    }
+
+    private function removeEscapesAndDuplicates(): array
+    {
+        $group = $this->unnecessaryGroupEscapes->remove($this->elements);
+        return $this->removeDuplicates($group);
+    }
+
+    private function removeDuplicates(array $elements): array
+    {
+        return (new PosixClassSimplifier($elements))->all();
     }
 }

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Literal.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Literal.php
@@ -1,0 +1,73 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+class Literal extends Model
+{
+    /** @var string */
+    private $literal;
+
+    public function __construct(string $literal)
+    {
+        $this->literal = $literal;
+    }
+
+    public function getContent(): string
+    {
+        return $this->collapseQuantifiers($this->literal);
+    }
+
+    private function collapseQuantifiers(string $text): string
+    {
+        return $this->replaceStringWithMap($text, [
+            '{0,1}' => '?',
+            '{0,}'  => '*',
+            '{1,}'  => '+',
+        ]);
+    }
+
+    private function replaceStringWithMap(string $string, array $map): string
+    {
+        return str_replace(array_keys($map), array_values($map), $string);
+    }
+
+    public function isSingleToken(): bool
+    {
+        return strlen($this->literal) === 1;
+    }
+
+    public function explodeByAlternative(): array
+    {
+        $split = $this->getSingleTokens();
+        if ($this->isLiteralComplex($split)) {
+            return [$this];
+        }
+        return $this->mapToLiteral($split);
+    }
+
+    private function getSingleTokens(): array
+    {
+        $split = explode('|', $this->literal);
+        return array_filter($split, function (string $s) {
+            return strlen($s) >= 1;
+        });
+    }
+
+    private function isLiteralComplex($split): bool
+    {
+        return count($this->getComplex($split)) > 1;
+    }
+
+    private function getComplex(array $elements)
+    {
+        return array_filter($elements, function (string $s) {
+            return strlen($s) > 1;
+        });
+    }
+
+    private function mapToLiteral(array $split): array
+    {
+        return array_map(function (string $s) {
+            return new Literal($s);
+        }, $split);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Model.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Model.php
@@ -1,0 +1,12 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+abstract class Model
+{
+    public abstract function getContent(): string;
+
+    public function isSingleToken(): bool
+    {
+        return false;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Model/Quote.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Model/Quote.php
@@ -1,0 +1,18 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Model;
+
+class Quote extends Model
+{
+    /** @var string */
+    private $quote;
+
+    public function __construct(string $quote)
+    {
+        $this->quote = $quote;
+    }
+
+    public function getContent(): string
+    {
+        return $this->quote;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/ModelFactory.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/ModelFactory.php
@@ -1,0 +1,31 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\EscapedLiteral;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Quote;
+
+class ModelFactory
+{
+    public function model(string $piece): Model
+    {
+        if ($this->isEscapedLiteral($piece)) {
+            return new EscapedLiteral($piece);
+        }
+        if ($this->isQuote($piece)) {
+            return new Quote($piece);
+        }
+        return new Literal($piece);
+    }
+
+    private function isEscapedLiteral(string $piece): bool
+    {
+        return strlen($piece) === 2 && $piece[0] == '\\';
+    }
+
+    private function isQuote(string $piece): bool
+    {
+        return substr($piece, 0, 2) === '\\Q';
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/ModelList.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/ModelList.php
@@ -1,0 +1,37 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+
+class ModelList
+{
+    /** @var Model[] */
+    private $models = [];
+
+    public function clear(): void
+    {
+        $this->models = [];
+    }
+
+    public function get(): array
+    {
+        return $this->models;
+    }
+
+    public function add(Model $model): void
+    {
+        $this->models[] = $model;
+    }
+
+    public function getAndClear(): array
+    {
+        $m = $this->models;
+        $this->models = [];
+        return $m;
+    }
+
+    public function addAll(array $elements): void
+    {
+        $this->models = array_merge($this->models, $elements);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifier.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifier.php
@@ -1,0 +1,47 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+use TRegx\CleanRegex\Analyze\Simplify\Alternative\AlternativeGrouper;
+use TRegx\CleanRegex\Analyze\Simplify\Set\SetGrouper;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Internal\InternalPattern;
+use TRegx\CleanRegex\Internal\PatternVerifier;
+
+class PatternSimplifier
+{
+    /** @var PatternVerifier */
+    private $verifier;
+
+    /** @var SetGrouper */
+    private $setGrouper;
+
+    /** @var AlternativeGrouper */
+    private $alternativeGrouper;
+
+    public function __construct(InternalPattern $pattern)
+    {
+        $this->verifier = new PatternVerifier($pattern->pattern);
+        $this->setGrouper = new SetGrouper(new QuotesBreaker($pattern->originalPattern), new ModelFactory());
+        $this->alternativeGrouper = new AlternativeGrouper();
+    }
+
+    public function simplify(): string
+    {
+        $this->verifier->verify();
+        return $this->simplifyPattern();
+    }
+
+    private function simplifyPattern(): string
+    {
+        $models = $this->setGrouper->getGrouped();
+        $grouped = $this->alternativeGrouper->getGrouped($models);
+        return join($this->getContent($grouped));
+    }
+
+    private function getContent(array $broken): array
+    {
+        return array_map(function (Model $model) {
+            return $model->getContent();
+        }, $broken);
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifier.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifier.php
@@ -2,7 +2,7 @@
 namespace TRegx\CleanRegex\Analyze\Simplify;
 
 use TRegx\CleanRegex\Analyze\Simplify\Alternative\AlternativeGrouper;
-use TRegx\CleanRegex\Analyze\Simplify\Set\SetGrouper;
+use TRegx\CleanRegex\Analyze\Simplify\Posix\SetGrouper;
 use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
 use TRegx\CleanRegex\Internal\InternalPattern;
 use TRegx\CleanRegex\Internal\PatternVerifier;

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/Element.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/Element.php
@@ -1,0 +1,9 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
+
+interface Element
+{
+    public function get(): string;
+
+    public function contains(Element $element): bool;
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/PosixClassSimplifier.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/PosixClassSimplifier.php
@@ -1,0 +1,18 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
+
+class PosixClassSimplifier
+{
+    /** @var string[] */
+    private $elements;
+
+    public function __construct(array $elements)
+    {
+        $this->elements = $elements;
+    }
+
+    public function all(): array
+    {
+        return $this->elements;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/RangeElement.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/RangeElement.php
@@ -1,0 +1,27 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
+
+class RangeElement implements Element
+{
+    /** @var string */
+    private $start;
+    /** @var string */
+    private $end;
+
+    public function __construct(string $start, string $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function get(): string
+    {
+        return "$this->start-$this->end";
+    }
+
+    public function contains(Element $element): bool
+    {
+        $value = $element->get();
+        return $value >= $this->start && $value <= $this->end;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SetGrouper.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SetGrouper.php
@@ -1,5 +1,5 @@
 <?php
-namespace TRegx\CleanRegex\Analyze\Simplify\Set;
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
 
 use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
 use TRegx\CleanRegex\Analyze\Simplify\ModelFactory;

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SetGrouperWorker.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SetGrouperWorker.php
@@ -1,5 +1,5 @@
 <?php
-namespace TRegx\CleanRegex\Analyze\Simplify\Set;
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
 
 use TRegx\CleanRegex\Analyze\Simplify\Model\Group;
 use TRegx\CleanRegex\Analyze\Simplify\Model\Model;

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SingleElement.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Posix/SingleElement.php
@@ -1,0 +1,23 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Posix;
+
+class SingleElement implements Element
+{
+    /** @var string */
+    private $element;
+
+    public function __construct(string $element)
+    {
+        $this->element = $element;
+    }
+
+    public function get(): string
+    {
+        return $this->element;
+    }
+
+    public function contains(Element $element): bool
+    {
+        return $this->element === $element;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/QuotesBreaker.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/QuotesBreaker.php
@@ -1,0 +1,55 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+use TRegx\SafeRegex\preg;
+
+class QuotesBreaker
+{
+    /** @var string */
+    private $pattern;
+
+    public function __construct(string $pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public function split(): array
+    {
+        return $this->joinQuotes($this->splitQuotesAndEscapes());
+    }
+
+    private function splitQuotesAndEscapes(): array
+    {
+        return preg::split('/(\\\\.|\[|\])/', $this->pattern, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+    }
+
+    private function joinQuotes(array $split): array
+    {
+        $result = [];
+        $current = '';
+        $quoting = false;
+
+        foreach ($split as $item) {
+            if ($quoting) {
+                $current .= $item;
+                if ($item === '\E') {
+                    $quoting = false;
+                    $result[] = $current;
+                }
+            } else {
+                if ($item === '\Q') {
+                    $quoting = true;
+                    $current = $item;
+                } else {
+                    $result[] = $item;
+                }
+            }
+        }
+
+        if ($quoting) {
+            $result[] = $current;
+        }
+
+        return $result;
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouper.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouper.php
@@ -1,0 +1,28 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Set;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Analyze\Simplify\ModelFactory;
+use TRegx\CleanRegex\Analyze\Simplify\QuotesBreaker;
+
+class SetGrouper
+{
+    /** @var QuotesBreaker */
+    private $breaker;
+    /** @var ModelFactory */
+    private $factory;
+
+    public function __construct(QuotesBreaker $breaker, ModelFactory $factory)
+    {
+        $this->breaker = $breaker;
+        $this->factory = $factory;
+    }
+
+    /**
+     * @return Model[]
+     */
+    public function getGrouped(): array
+    {
+        return (new SetGrouperWorker($this->breaker->split(), $this->factory))->getGrouped();
+    }
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperWorker.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperWorker.php
@@ -1,0 +1,102 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify\Set;
+
+use TRegx\CleanRegex\Analyze\Simplify\Model\Group;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Model;
+use TRegx\CleanRegex\Analyze\Simplify\ModelFactory;
+
+class SetGrouperWorker
+{
+    /** @var array */
+    private $pieces;
+    /** @var ModelFactory */
+    private $factory;
+
+    /** @var Model[] */
+    private $result;
+    /** @var string[] */
+    private $group;
+    /** @var bool */
+    private $isGrouping;
+    /** @var int|null */
+    private $groupStartIndex;
+
+    public function __construct(array $pieces, ModelFactory $factory)
+    {
+        $this->pieces = $pieces;
+        $this->factory = $factory;
+
+        $this->result = [];
+        $this->group = [];
+        $this->isGrouping = false;
+        $this->groupStartIndex = null;
+    }
+
+    /**
+     * @return Model[]
+     */
+    public function getGrouped(): array
+    {
+        foreach ($this->pieces as $i => $piece) {
+            if ($piece === '[') {
+                $this->setStart($piece, $i);
+            }
+            else if ($piece === ']') {
+                $this->setEnd($piece, $i);
+            }
+            else {
+                $this->literal($piece);
+            }
+        }
+        return $this->result;
+    }
+
+    private function setStart(string $piece, int $index): void
+    {
+        if ($this->isGrouping) {
+            $this->group[] = $piece;
+        }
+        else {
+            $this->isGrouping = true;
+            $this->groupStartIndex = $index;
+        }
+    }
+
+    private function setEnd(string $piece, int $index): void
+    {
+        if ($this->isGrouping) {
+            if ($this->wasGroupJustOpened($index)) {
+                $this->group[] = $piece;
+            }
+            else {
+                $this->isGrouping = false;
+                $this->result[] = new Group($this->group);
+                $this->group = [];
+            }
+        }
+        else {
+            $this->addResultModel($piece);
+        }
+    }
+
+    private function literal(string $piece): void
+    {
+        if ($this->isGrouping) {
+            $this->group[] = $piece;
+        }
+        else {
+            $this->addResultModel($piece);
+        }
+    }
+
+    private function wasGroupJustOpened(int $index): bool
+    {
+        return $index - 1 === $this->groupStartIndex;
+    }
+
+    private function addResultModel(string $piece): void
+    {
+        $this->result[] = $this->factory->model($piece);
+    }
+
+}

--- a/src/TRegx/CleanRegex/Analyze/Simplify/UnnecessaryGroupEscapes.php
+++ b/src/TRegx/CleanRegex/Analyze/Simplify/UnnecessaryGroupEscapes.php
@@ -1,0 +1,53 @@
+<?php
+namespace TRegx\CleanRegex\Analyze\Simplify;
+
+class UnnecessaryGroupEscapes
+{
+    /** @var LiteralLetters */
+    private $literalTokens;
+
+    /** @var boolean */
+    private $escapeClosingGroup;
+
+    public function __construct(LiteralLetters $literalTokens, bool $escapeClosingGroup)
+    {
+        $this->literalTokens = $literalTokens;
+        $this->escapeClosingGroup = $escapeClosingGroup;
+    }
+
+    public function remove(array $tokens): array
+    {
+        return array_map(function (string $token) {
+            if ($token[0] !== '\\') {
+                return $token;
+            }
+            return $this->addQuoteIfRequired($token[1]);
+        }, $tokens);
+    }
+
+    public function addQuoteIfRequired(string $character): string
+    {
+        if ($this->isEscapeRequired($character)) {
+            return "\\" . $character;
+        }
+        return $character;
+    }
+
+    private function isEscapeRequired($character): bool
+    {
+        return $this->isEscapeCharacter($character) || $this->literalTokens->isLetterNotLiteral($character);
+    }
+
+    private function isEscapeCharacter(string $character): bool
+    {
+        return in_array($character, $this->escapeCharacters());
+    }
+
+    private function escapeCharacters(): array
+    {
+        if ($this->escapeClosingGroup) {
+            return [']', '\\'];
+        }
+        return ['\\'];
+    }
+}

--- a/src/TRegx/CleanRegex/AnalyzePattern.php
+++ b/src/TRegx/CleanRegex/AnalyzePattern.php
@@ -1,0 +1,21 @@
+<?php
+namespace TRegx\CleanRegex;
+
+use TRegx\CleanRegex\Analyze\Simplify\PatternSimplifier;
+use TRegx\CleanRegex\Internal\InternalPattern;
+
+class AnalyzePattern
+{
+    /** @var InternalPattern */
+    private $pattern;
+
+    public function __construct(InternalPattern $pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public function simplify(): string
+    {
+        return (new PatternSimplifier($this->pattern))->simplify();
+    }
+}

--- a/src/TRegx/CleanRegex/Internal/Delimiter/Delimiterer.php
+++ b/src/TRegx/CleanRegex/Internal/Delimiter/Delimiterer.php
@@ -8,9 +8,9 @@ class Delimiterer
     /** @var DelimiterParser */
     private $parser;
 
-    public function __construct()
+    public function __construct(DelimiterParser $parser)
     {
-        $this->parser = new DelimiterParser();
+        $this->parser = $parser;
     }
 
     public function delimiter(string $pattern): string

--- a/src/TRegx/CleanRegex/Internal/FlagsValidator.php
+++ b/src/TRegx/CleanRegex/Internal/FlagsValidator.php
@@ -1,7 +1,6 @@
 <?php
 namespace TRegx\CleanRegex\Internal;
 
-use TRegx\CleanRegex\Exception\CleanRegex\FlagNotAllowedException;
 use function in_array;
 use function str_split;
 
@@ -22,24 +21,24 @@ class FlagsValidator
 
     /**
      * @param string $flags
-     * @return void
-     * @throws FlagNotAllowedException
+     * @return bool
      */
-    public function validate(string $flags): void
+    public function isValid(string $flags): bool
     {
         if (empty($flags)) {
-            return;
+            return true;
         }
-        $this->validateFlags($flags);
+        return $this->areFlagsValid($flags);
     }
 
-    private function validateFlags(string $flags): void
+    private function areFlagsValid(string $flags): bool
     {
         foreach (str_split($flags) as $flag) {
             if (!$this->isAllowed($flag)) {
-                throw new FlagNotAllowedException($flag);
+                return false;
             }
         }
+        return true;
     }
 
     private function isAllowed(string $character): bool

--- a/src/TRegx/CleanRegex/Internal/InternalPattern.php
+++ b/src/TRegx/CleanRegex/Internal/InternalPattern.php
@@ -2,6 +2,7 @@
 namespace TRegx\CleanRegex\Internal;
 
 use TRegx\CleanRegex\Internal\Delimiter\Delimiterer;
+use TRegx\CleanRegex\Internal\Delimiter\DelimiterParser;
 
 class InternalPattern
 {
@@ -13,7 +14,7 @@ class InternalPattern
 
     public function __construct(string $pattern, string $flags = '')
     {
-        $this->pattern = (new Delimiterer())->delimiter($pattern) . $flags;
+        $this->pattern = (new Delimiterer(new DelimiterParser(new FlagsValidator())))->delimiter($pattern) . $flags;
         $this->originalPattern = $pattern;
     }
 }

--- a/src/TRegx/CleanRegex/IsPattern.php
+++ b/src/TRegx/CleanRegex/IsPattern.php
@@ -2,6 +2,7 @@
 namespace TRegx\CleanRegex;
 
 use TRegx\CleanRegex\Internal\Delimiter\DelimiterParser;
+use TRegx\CleanRegex\Internal\FlagsValidator;
 use TRegx\CleanRegex\Internal\InternalPattern;
 use TRegx\CleanRegex\Internal\PatternVerifier;
 
@@ -28,6 +29,6 @@ class IsPattern
     public function delimitered(): bool
     {
         (new PatternVerifier($this->pattern->pattern))->verify();
-        return (new DelimiterParser())->isDelimitered($this->pattern->originalPattern);
+        return (new DelimiterParser(new FlagsValidator()))->isDelimitered($this->pattern->originalPattern);
     }
 }

--- a/src/TRegx/CleanRegex/Pattern.php
+++ b/src/TRegx/CleanRegex/Pattern.php
@@ -72,6 +72,11 @@ class Pattern
         return $this->pattern->pattern;
     }
 
+    public function analyze(): AnalyzePattern
+    {
+        return new AnalyzePattern($this->pattern);
+    }
+
     public static function of(string $pattern, string $flags = ''): Pattern
     {
         return new Pattern($pattern, $flags);

--- a/test/DataProviders.php
+++ b/test/DataProviders.php
@@ -15,9 +15,9 @@ class DataProviders
             ['/\\/'],
             ['/(/'],
             ['/{1}/'],
+            ['//[a-z]']
         ];
     }
-
 
     public function invalidUtf8Sequences()
     {

--- a/test/Integration/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
+++ b/test/Integration/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Test\Integration\TRegx\CleanRegex\Analyze\Simplify;
+
+use PHPUnit\Framework\TestCase;
+
+class PatternSimplifierTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldSimplify()
+    {
+        // when
+        $simplified = pattern('(?:a|b|c){1,}')->analyze()->simplify();
+
+        // then
+        $this->assertEquals('[abc]+', $simplified);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSimplify_withDelimiters()
+    {
+        // when
+        $simplified = pattern('/(?:a|b|c){1,}/')->analyze()->simplify();
+
+        // then
+        $this->assertEquals('/[abc]+/', $simplified);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSimplify_withFlag()
+    {
+        // when
+        $simplified = pattern('(?:a|b|c){1,}', 'i')->analyze()->simplify();
+
+        // then
+        $this->assertEquals('[abc]+', $simplified);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSimplify_withDelimiters_withoutFlag()
+    {
+        // when
+        $simplified = pattern('/(?:a|b|c){1,}/', 'i')->analyze()->simplify();
+
+        // then
+        $this->assertEquals('[abc]+', $simplified);
+    }
+}

--- a/test/Integration/TRegx/CleanRegex/ReadMeTest.php
+++ b/test/Integration/TRegx/CleanRegex/ReadMeTest.php
@@ -476,8 +476,8 @@ class ReadMeTest extends TestCase
      * @test
      * @dataProvider validPatterns
      * @param string $pattern
-     * @param bool $expectedValid
-     * @param bool $expectedUsable
+     * @param bool   $expectedValid
+     * @param bool   $expectedUsable
      */
     public function validatePattern(string $pattern, bool $expectedValid, bool $expectedUsable)
     {
@@ -486,8 +486,8 @@ class ReadMeTest extends TestCase
         $usable = pattern($pattern)->is()->usable();
 
         // then
-        $this->assertEquals($expectedValid, $valid);
-        $this->assertEquals($expectedUsable, $usable);
+        $this->assertEquals($expectedValid, $valid, "Failed asserting that '$pattern' is valid");
+        $this->assertEquals($expectedUsable, $usable, "Failed asserting that '$pattern' is usable");
     }
 
     function validPatterns()
@@ -495,7 +495,7 @@ class ReadMeTest extends TestCase
         return [
             ['/[a-z]/im', true, true],
             ['[a-z]+', false, true],
-            ['//[a-z]', false, false],
+            ['//[a-z]', false, true],
             ['/(unclosed/', false, false],
         ];
     }

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltJoinerTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltJoinerTest.php
@@ -1,0 +1,116 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\Alternative\LiteralAltJoiner;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Alt;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltEnd;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltStart;
+use TRegx\CleanRegex\Analyze\Simplify\Model\EscapedLiteral;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+
+class LiteralAltJoinerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldJoin_onlyNested()
+    {
+        // given
+        $models = [
+            new Literal('0'),
+            new AltStart(),
+            new Literal('a'),
+            new AltStart(),
+            new Literal('k'),
+            new EscapedLiteral('\.'),
+            new AltEnd(),
+            new Literal('k'),
+            new AltEnd(),
+            new Literal('z'),
+        ];
+        $factory = new LiteralAltJoiner($models);
+
+        // when
+        $transformed = $factory->join();
+
+        // then
+        $expected = [
+            new Literal('0'),
+            new AltStart(),
+            new Literal('a'),
+            new Alt([
+                new Literal('k'),
+                new EscapedLiteral('\.'),
+            ]),
+            new Literal('k'),
+            new AltEnd(),
+            new Literal('z'),
+        ];
+        $this->assertEquals($expected, $transformed);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldJoin_jagged()
+    {
+        // given
+        $models = [
+            new AltStart(),
+            new AltStart(),
+            new AltStart(),
+            new Literal('a'),
+            new AltEnd(),
+            new AltEnd(),
+            new AltStart(),
+            new Literal('k'),
+            new AltEnd(),
+            new AltEnd(),
+        ];
+        $factory = new LiteralAltJoiner($models);
+
+        // when
+        $transformed = $factory->join();
+
+        // then
+        $expected = [
+            new AltStart(),
+            new AltStart(),
+            new Alt([
+                new Literal('a'),
+            ]),
+            new AltEnd(),
+            new Alt([
+                new Literal('k'),
+            ]),
+            new AltEnd(),
+        ];
+        $this->assertEquals($expected, $transformed);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldJoin_empty()
+    {
+        // given
+        $models = [
+            new AltEnd(),
+            new AltStart(),
+            new AltEnd(),
+        ];
+        $factory = new LiteralAltJoiner($models);
+
+        // when
+        $transformed = $factory->join();
+
+        // then
+        $expected = [
+            new AltEnd(),
+            new Alt([
+            ]),
+        ];
+        $this->assertEquals($expected, $transformed);
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltSplitterTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Alternative/LiteralAltSplitterTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify\Alternative;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\Alternative\LiteralAltSplitter;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltEnd;
+use TRegx\CleanRegex\Analyze\Simplify\Model\AltStart;
+use TRegx\CleanRegex\Analyze\Simplify\Model\EscapedLiteral;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+
+class LiteralAltSplitterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldTransform()
+    {
+        // given
+        $models = [
+            new Literal('before'),
+            new Literal('open (?: nested (?:a|b|'),
+            new EscapedLiteral('\.'),
+            new Literal('|c) close'),
+            new Literal('open (?:a|b|'),
+            new Literal('|c) close'),
+            new Literal(') close'),
+            new Literal('end'),
+        ];
+        $factory = new LiteralAltSplitter($models);
+
+        // when
+        $transformed = $factory->split();
+
+        // then
+        $expected = [
+            new Literal('before'),
+            new Literal('open '),
+            new AltStart(),
+            new Literal(' nested '),
+            new AltStart(),
+            new Literal('a|b|'),
+            new EscapedLiteral('\.'),
+            new Literal('|c'),
+            new AltEnd(),
+            new Literal(' close'),
+            new Literal('open '),
+            new AltStart(),
+            new Literal('a|b|'),
+            new Literal('|c'),
+            new AltEnd(),
+            new Literal(' close'),
+            new AltEnd(),
+            new Literal(' close'),
+            new Literal('end'),
+        ];
+        $this->assertEquals($expected, $transformed);
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/CodePointTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/CodePointTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\CodePoint;
+
+class CodePointTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider indexes
+     * @param string $character
+     * @param int    $expectedIndex
+     */
+    public function shouldIndex(string $character, int $expectedIndex)
+    {
+        // given
+        $characterIndex = new CodePoint($character);
+
+        // when
+        $index = $characterIndex->index();
+
+        // then
+        $this->assertEquals($expectedIndex, $index);
+    }
+
+    public function indexes(): array
+    {
+        return [
+            ['ą', 261],
+            ['ę', 281],
+            ['ź', 378],
+            ['(', 40],
+            [')', 41],
+            ['ß', 223],
+        ];
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
@@ -1,0 +1,196 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\PatternSimplifier;
+use TRegx\CleanRegex\Exception\CleanRegex\InvalidPatternException;
+use TRegx\CleanRegex\Internal\InternalPattern;
+
+class PatternSimplifierTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider toBeSimplified
+     * @param string $complex
+     * @param string $expected
+     */
+    public function shouldSimplify(string $complex, string $expected)
+    {
+        // given
+        $simplifier = new PatternSimplifier(new InternalPattern($complex));
+
+        // when
+        $simplified = $simplifier->simplify();
+
+        // then
+        $this->assertEquals($expected, $simplified);
+    }
+
+    public function toBeSimplified()
+    {
+        return [
+            // Character groups (digits)
+            'numbers token \d #1'        => ['Number [0-9]', 'Number \d'],
+            'numbers token \d #2'        => ['Word [0-9]as]', 'Word \das]'],
+            'numbers token \D #3'        => ['Not numbers [^0-9]', 'Not numbers \D'],
+
+            // Character groups (word)
+            'word token \w #1'           => ['Word [a-zA-Z0-9_]', 'Word \w'],
+            'word token \w #2'           => ['Word [A-Za-z_0-9]', 'Word \w'],
+            'word token \w #3'           => ['Word [A-Z0-9a-z_]', 'Word \w'],
+            'word token \W #1'           => ['Not a word [^a-zA-Z0-9_]', 'Not a word \W'],
+            'word token \W #2'           => ['Not a word [^A-Z0-9_a-z]', 'Not a word \W'],
+            'word token \W #3'           => ['Not a word [^A-Z_0-9a-z]', 'Not a word \W'],
+
+            // Unnecessary escaping
+            'unnecessary escape'         => ['Apostrophe \" and space\ ', 'Apostrophe " and space '],
+            'unnecessary escape \m'      => ['Word \m', 'Word m'],
+            'unnecessary escape (group)' => ['Group escaping [\.\]\|\?\[\)]', 'Group escaping [.\]|?[)]'],
+
+            // Character groups - corner cases
+            'single char group #1'       => ['Word [a]', 'Word a'],
+            'single char group #2'       => ['Word [\a]', 'Word \a'],
+            'single char group #3'       => ['Word [\]]', 'Word \]'],
+            'single char group #4'       => ['Word [)]', 'Word \)'],
+            'single char group #5'       => ['Word [[]', 'Word \['],
+
+            // Quantifiers
+            'quantifiers ?'              => ['Word{0,1}', 'Word?'],
+            'quantifiers *'              => ['Maybe{0,}', 'Maybe*'],
+            'quantifiers +'              => ['Maybe{1,}', 'Maybe+'],
+
+            // Quoted
+            'quoted alt'                 => ['\Q(b|c|d)\E [0-9]', '\Q(b|c|d)\E \d'],
+
+            // Alternatives
+            'alt #1'                     => ['(?:b|c|d|\.)', '[bcd.]'],
+            'alt #2'                     => ['(?:b|\(|\]|\.)', '[b(\].]'],
+            'alt #3'                     => ['(?:b|\(\|)', '[b(|]'],
+            'alt #4'                     => ['(?:b|c|d) [0-9]', '[bcd] \d'],
+            'alt #5'                     => ['(?:a|b|c)', '[abc]'],
+            'alt $6'                     => ['(?:a|b|c|\.|d)', '[abc.d]'],
+
+            // Escaped control characters
+            [
+                '\A\B\C\D\E\F\G\H\I\J\K\M\N\O\PP\Q\E\R\S\T\V\W\X\Y\Z',
+                '\A\B\C\D\EF\G\HIJ\KM\NO\PP\Q\E\R\ST\V\W\XY\Z',
+            ],
+            [
+                "((?'name'))" . '\a\b\c2\d\e\f\g{2}\h\i\j\k\'name\'\m\n\o{1}\pP\q\r\s\t\v\w\x\y\z',
+                "((?'name'))" . '\a\b\c2\d\e\f\g{2}\hij\k\'name\'m\n\o{1}\pPq\r\s\t\v\w\xy\z',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider notToBeSimplified
+     * @param string $escaped
+     */
+    public function shouldNotSimplify_escaped(string $escaped)
+    {
+        // given
+        $simplifier = new PatternSimplifier(new InternalPattern($escaped));
+
+        // when
+        $simplified = $simplifier->simplify();
+
+        // then
+        $this->assertEquals($escaped, $simplified);
+    }
+
+    public function notToBeSimplified()
+    {
+        return [
+            // Escaped
+            'escaped group #1'      => ['Number \[0-9]'],
+            'escaped group #2'      => ['Word [0-9\]as]'],
+            'escaped quantifier #1' => ['Word\{0,1}'],
+            'escaped quantifier #2' => ['Maybe\{0,}'],
+            'escaped quantifier #3' => ['Maybe\{1,}'],
+            'escaped quantifier #4' => ['Maybe{1,\}'],
+            'escaped quantifier #5' => ['Maybe{1\,}'],
+            'escaped alt'           => ['One word groups \(b|c|d\)'],
+            'escaped char #1 \a'    => ['Word \a'],
+            'escaped char #2 \b'    => ['Word \b'],
+            'escaped char #2 \\\\b' => ['Word \\\\b'],
+
+            // Quoted
+            'quote #1'              => ['Number \Q[0-9]'],
+            'quote #2'              => ['Not numbers \Q[^0-9]'],
+            'quote #3'              => ['Word \Q[a-zA-Z0-9_]'],
+            'quote #4'              => ['Not a word \Q[^a-zA-Z0-9_]'],
+            'quote #5'              => ['Letter \Q\and'],
+            'quote #6'              => ['Apostrophe  \Q\and\"'],
+            'quote #7'              => ['Group \Q[a] escaping [\.\]\|\?\[\)]'],
+            'quote #8'              => ['Group \Q[]0-9]'],
+            'quote #9'              => ['Word \Q[0-9]as\]'],
+            'quote #10'             => ['Word \Q{0,1}'],
+            'quote #11'             => ['Maybe \Q{0,}'],
+            'quote #12'             => ['One word groups \Q(b|c|d)'],
+            'quote #13'             => ['Escaped alternative \Q\(b|c|d\)'],
+
+            // Quoted alternative
+            'quoted alt'            => ['One word groups (?:b|\Q\(|\E)'],
+
+            // Groups
+            'unclosed group #1'     => ['Group []0-9]'],
+            'unclosed group #2'     => ['Group [0-9[]'],
+
+            // Alternatives
+            'alternative #1'        => ['One word groups (b|c|d|\.)'],
+            'alternative #2'        => ['One word groups (?<name>b|c|d|\.)'],
+            'alternative #3'        => ['One word groups (?P<name>b|c|d|\.)'],
+            'alternative #4'        => ['One word groups (?\'name\'b|c|d|\.)'],
+
+            // Back reference
+            'back reference #1'     => ['group () \1'],
+            'back reference #2'     => ['Group (()) \2']
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldThrow_onInvalid()
+    {
+        // given
+        $simplifier = new PatternSimplifier(new InternalPattern('invalid (a|'));
+
+        // then
+        $this->expectException(InvalidPatternException::class);
+
+        // when
+        $simplifier->simplify();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSimplify_multipleEscaping()
+    {
+        // given
+        $escaped = str_repeat('\\', 12);
+        $simplifier = new PatternSimplifier(new InternalPattern("$escaped{1,}"));
+
+        // when
+        $simplified = $simplifier->simplify();
+
+        $this->assertEquals($escaped . '+', $simplified);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSimplify_not_multipleEscaping()
+    {
+        // given
+        $escaped = str_repeat('\\', 13);
+        $simplifier = new PatternSimplifier(new InternalPattern("$escaped{1,}"));
+
+        // when
+        $simplified = $simplifier->simplify();
+
+        $this->assertEquals($escaped . '{1,}', $simplified);
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
@@ -29,6 +29,9 @@ class PatternSimplifierTest extends TestCase
     public function toBeSimplified()
     {
         return [
+            // Character groups - repeating
+            'repeating char group'       => ['Repeat [abca]', 'Repeat [abc]'],
+
             // Character groups (digits)
             'numbers token \d #1'        => ['Number [0-9]', 'Number \d'],
             'numbers token \d #2'        => ['Word [0-9]as]', 'Word \das]'],

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/PatternSimplifierTest.php
@@ -29,8 +29,13 @@ class PatternSimplifierTest extends TestCase
     public function toBeSimplified()
     {
         return [
+            'hex set range'              => ['Well [\x14-\x16-\x15] with', 'Well [\x14-\x16-] with'],
+
             // Character groups - repeating
-            'repeating char group'       => ['Repeat [abca]', 'Repeat [abc]'],
+            'repeating char group #1'    => ['Repeat [abca]', 'Repeat [abc]'],
+            'repeating char group #2'    => ['Repeat [99]', 'Repeat [9]'],
+            'repeating char group #3'    => ['Repeat [\..]', 'Repeat \.'],
+            'repeating char group #4'    => ['Repeat [\..,]', 'Repeat [.,]'],
 
             // Character groups (digits)
             'numbers token \d #1'        => ['Number [0-9]', 'Number \d'],

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/QuotesBreakerTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/QuotesBreakerTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\QuotesBreaker;
+
+class QuotesBreakerTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider patterns
+     * @param string $pattern
+     * @param array  $expected
+     */
+    public function shouldSplit(string $pattern, array $expected)
+    {
+        // given
+        $breaker = new QuotesBreaker($pattern);
+
+        // when
+        $split = $breaker->split();
+
+        // then
+        $this->assertEquals($expected, $split);
+    }
+
+    public function patterns(): array
+    {
+        return [
+            ['unquoted [a-z]', ['unquoted ', '[', 'a-z', ']']],
+            ['quoted \[a-z]', ['quoted ', '\[', 'a-z', ']']],
+            ['double quoted \\\[a-z]', ['double quoted ', '\\\\', '[', 'a-z', ']']],
+            ['closed group []a-z]', ['closed group ', '[', ']', 'a-z', ']']],
+
+            [
+                '(a|b) \\\Q \\\\\\[a-z] \E',
+                [
+                    '(a|b) ',
+                    '\\\\',
+                    'Q ',
+                    '\\\\',
+                    '\\[',
+                    'a-z',
+                    ']',
+                    ' ',
+                    '\E'
+                ]
+            ],
+
+            [
+                '[a-z] \\\Q\Q \\\\\\[a-z] \E [a-z\.] \E\E',
+                [
+                    '[',
+                    'a-z',
+                    ']',
+                    ' ',
+                    '\\\\',
+                    'Q',
+                    '\Q \\\\\\[a-z] \E',
+                    ' ',
+                    '[',
+                    'a-z',
+                    '\.',
+                    ']',
+                    ' ',
+                    '\E',
+                    '\E'
+                ]
+            ],
+        ];
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/PosixClassSimplifierTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/PosixClassSimplifierTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify\Set;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\Posix\PosixClassSimplifier;
+
+class PosixClassSimplifierTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider inputAndOutput
+     * @param array $input
+     * @param array $output
+     */
+    public function shouldGetAll(array $input, array $output)
+    {
+        // given
+        $set = new PosixClassSimplifier($input);
+
+        // when
+        $all = $set->all();
+
+        // then
+        $this->assertEquals($output, $all);
+    }
+
+    public function inputAndOutput()
+    {
+        return [
+            // duplicates
+            [['aba'], ['aba']],
+            [['.', '.'], ['.']],
+            [['a', 'b', 'a'], ['ab']],
+            [['1-98'], ['1-9']],
+            [['81-'], ['81-']],
+            [['a-za', 'a'], ['a-z']],
+            [['\d', '0-9'], ['\d']],
+            [['0-9', '\d'], ['\d']],
+            [['5-76'], ['5-7']],
+            [['a-a'], ['a']],
+            [['9-9'], ['9']],
+
+            // control characters
+            [['^^'], ['^^']],
+            [['^^^'], ['^^']],
+            [['-0-9-'], ['-0-9']],
+            [['-0-9'], ['-0-9']],
+            [['0-9-'], ['0-9-']],
+            [['^-0-9-'], ['-0-9']],
+            [['^-0-9'], ['-0-9']],
+            [['^0-9-'], ['0-9-']],
+            [['0-9-a-z'], ['0-9-a-z']],
+            [['0-9a-z-'], ['0-9a-z-']],
+            [['-0-9-a-z'], ['-0-9a-z']],
+            [['0-9-a-z-'], ['0-9-a-z']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider inputAndOutput
+     * @param array $input
+     * @param array $output
+     */
+    public function shouldGetAll_negated(array $input, array $output)
+    {
+        // given
+        $negated = array_merge(['^'], $input);
+        $set = new PosixClassSimplifier($negated);
+
+        // when
+        $all = $set->all();
+
+        // then
+        $this->assertEquals($output, $all);
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperTest.php
@@ -1,0 +1,114 @@
+<?php
+namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify\Set;
+
+use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Analyze\Simplify\Set\SetGrouper;
+use TRegx\CleanRegex\Analyze\Simplify\Model\EscapedLiteral;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Group;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;
+use TRegx\CleanRegex\Analyze\Simplify\Model\Quote;
+use TRegx\CleanRegex\Analyze\Simplify\ModelFactory;
+use TRegx\CleanRegex\Analyze\Simplify\QuotesBreaker;
+
+class GrouperTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider patterns
+     * @param string $pattern
+     * @param array  $expected
+     */
+    public function shouldCreate(string $pattern, array $expected)
+    {
+        // given
+        $factory = new SetGrouper(new QuotesBreaker($pattern), new ModelFactory());
+
+        // when
+        $models = $factory->getGrouped();
+
+        // then
+        $this->assertEquals($expected, $models);
+    }
+
+    public function patterns(): array
+    {
+        return [
+            [
+                'opened group #2 [[]',
+                [
+                    new Literal('opened group #2 '),
+                    new Group(['['])
+                ]
+            ],
+            [
+                'closed group []a-z]',
+                [
+                    new Literal('closed group '),
+                    new Group([']', 'a-z'])
+                ]
+            ],
+            [
+                'opened group #1 [[a-z]',
+                [
+                    new Literal('opened group #1 '),
+                    new Group(['[', 'a-z'])
+                ]
+            ],
+            [
+                'unquoted [a-z]',
+                [
+                    new Literal('unquoted '),
+                    new Group(['a-z'])
+                ]
+            ],
+
+            [
+                'double quoted \\\[a-z]',
+                [
+                    new Literal('double quoted '),
+                    new EscapedLiteral('\\\\'),
+                    new Group(['a-z'])
+                ]
+            ],
+            [
+                'quote \\\Q \\\\\\[a-z] \E',
+                [
+                    new Literal('quote '),
+                    new EscapedLiteral('\\\\'),
+                    new Literal('Q '),
+                    new EscapedLiteral('\\\\'),
+                    new EscapedLiteral('\\['),
+                    new Literal('a-z'),
+                    new Literal(']'),
+                    new Literal(' '),
+                    new EscapedLiteral('\E')
+                ]
+            ],
+
+            [
+                '[a-z] embedded quotes \\\Q\Q \\\\\\[a-z] \E [a-z\.] \E\E',
+                [
+                    new Group(['a-z']),
+                    new Literal(' embedded quotes '),
+                    new EscapedLiteral('\\\\'),
+                    new Literal('Q'),
+                    new Quote('\Q \\\\\\[a-z] \E'),
+                    new Literal(' '),
+                    new Group(['a-z', '\.']),
+                    new Literal(' '),
+                    new EscapedLiteral('\E'),
+                    new EscapedLiteral('\E')
+                ]
+            ],
+
+            [
+                '\\\\ \Q not ended quote',
+                [
+                    new EscapedLiteral('\\\\'),
+                    new Literal(' '),
+                    new Quote('\Q not ended quote'),
+                ]
+            ],
+        ];
+    }
+}

--- a/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperTest.php
+++ b/test/Unit/TRegx/CleanRegex/Analyze/Simplify/Set/SetGrouperTest.php
@@ -2,7 +2,7 @@
 namespace Test\Unit\TRegx\CleanRegex\Analyze\Simplify\Set;
 
 use PHPUnit\Framework\TestCase;
-use TRegx\CleanRegex\Analyze\Simplify\Set\SetGrouper;
+use TRegx\CleanRegex\Analyze\Simplify\Posix\SetGrouper;
 use TRegx\CleanRegex\Analyze\Simplify\Model\EscapedLiteral;
 use TRegx\CleanRegex\Analyze\Simplify\Model\Group;
 use TRegx\CleanRegex\Analyze\Simplify\Model\Literal;

--- a/test/Unit/TRegx/CleanRegex/Internal/CompositePatternMapperTest.php
+++ b/test/Unit/TRegx/CleanRegex/Internal/CompositePatternMapperTest.php
@@ -20,7 +20,7 @@ class CompositePatternMapperTest extends TestCase
             '[A-Z]+',
             '/[A-Z0-9]+/',
             '/[A-Z+]/i',
-            pattern('[A-Za-z]+', 'u'),
+            pattern('[A-Za-z]+', 'i'),
         ]);
 
         // when
@@ -31,7 +31,7 @@ class CompositePatternMapperTest extends TestCase
             '/[A-Z]+/',
             '/[A-Z0-9]+/',
             '/[A-Z+]/i',
-            '/[A-Za-z]+/u'
+            '/[A-Za-z]+/i'
         ];
         $actual = array_map(function (InternalPattern $pattern) {
             return $pattern->pattern;

--- a/test/Unit/TRegx/CleanRegex/Internal/Delimiter/DelimiterParserTest.php
+++ b/test/Unit/TRegx/CleanRegex/Internal/Delimiter/DelimiterParserTest.php
@@ -3,6 +3,7 @@ namespace Test\Unit\TRegx\CleanRegex\Internal\Delimiter;
 
 use TRegx\CleanRegex\Internal\Delimiter\DelimiterParser;
 use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Internal\FlagsValidator;
 
 class DelimiterParserTest extends TestCase
 {
@@ -11,7 +12,10 @@ class DelimiterParserTest extends TestCase
         return [
             ['//', '/'],
             ['/a/', '/'],
-            ['/siema/', '/'],
+            ['/word/', '/'],
+            ['//im', '/'],
+            ['/word/im', '/'],
+
             ['/sie#ma/', '/'],
             ['#sie/ma#', '#'],
             ['%si/e#ma%', '%'],
@@ -31,13 +35,30 @@ class DelimiterParserTest extends TestCase
     public function shouldGetDelimiter(string $pattern, string $delimiter)
     {
         // given
-        $delimiterer = new DelimiterParser();
+        $delimiterer = new DelimiterParser(new FlagsValidator());
 
         // when
         $result = $delimiterer->getDelimiter($pattern);
 
         // then
-        $this->assertEquals($delimiter, $result);
+        $this->assertEquals($delimiter, $result, "Failed asserting that '$result' is a delimiter of '$pattern'");
+    }
+
+    /**
+     * @test
+     * @dataProvider delimitered
+     * @param string $pattern
+     */
+    public function shouldBeDelimitered(string $pattern)
+    {
+        // given
+        $delimiterer = new DelimiterParser(new FlagsValidator());
+
+        // when
+        $result = $delimiterer->isDelimitered($pattern);
+
+        // then
+        $this->assertTrue($result);
     }
 
     public function notDelimitered()
@@ -46,13 +67,19 @@ class DelimiterParserTest extends TestCase
             [''],
             ['a'],
             ['/'],
-            ['siema'],
+            ['///'],
+            ['//12'],
+            ['//abc'],
+
+            ['word'],
             ['sie#ma'],
             ['si/e#ma'],
             ['s~i/e#m%a'],
             ['s~i/e#++m%a'],
 
-            ['/siema'],
+            ['/word'],
+            ['/word/2'],
+            ['/word/word/'],
             ['/sie#ma'],
             ['#sie/ma'],
             ['%si/e#ma'],
@@ -70,13 +97,13 @@ class DelimiterParserTest extends TestCase
     public function shouldNotGetDelimiter(string $pattern)
     {
         // given
-        $delimiterer = new DelimiterParser();
+        $delimiterer = new DelimiterParser(new FlagsValidator());
 
         // when
         $result = $delimiterer->getDelimiter($pattern);
 
         // then
-        $this->assertNull($result);
+        $this->assertNull($result, "Failed asserting that '$pattern' does not have a delimiter");
     }
 
     /**
@@ -87,29 +114,12 @@ class DelimiterParserTest extends TestCase
     public function shouldNotBeDelimitered(string $pattern)
     {
         // given
-        $delimiterer = new DelimiterParser();
+        $delimiterer = new DelimiterParser(new FlagsValidator());
 
         // when
         $result = $delimiterer->isDelimitered($pattern);
 
         // then
-        $this->assertFalse($result);
-    }
-
-    /**
-     * @test
-     * @dataProvider delimitered
-     * @param string $pattern
-     */
-    public function shouldBeDelimitered(string $pattern)
-    {
-        // given
-        $delimiterer = new DelimiterParser();
-
-        // when
-        $result = $delimiterer->isDelimitered($pattern);
-
-        // then
-        $this->assertTrue($result);
+        $this->assertFalse($result, "Failed asserting that '$pattern' is not delimiter");
     }
 }

--- a/test/Unit/TRegx/CleanRegex/Internal/Delimiter/DelimitererTest.php
+++ b/test/Unit/TRegx/CleanRegex/Internal/Delimiter/DelimitererTest.php
@@ -2,8 +2,10 @@
 namespace Test\Unit\TRegx\CleanRegex\Internal\Delimiter;
 
 use TRegx\CleanRegex\Internal\Delimiter\Delimiterer;
+use TRegx\CleanRegex\Internal\Delimiter\DelimiterParser;
 use TRegx\CleanRegex\Internal\Delimiter\ExplicitDelimiterRequiredException;
 use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Internal\FlagsValidator;
 
 class DelimitererTest extends TestCase
 {
@@ -35,7 +37,7 @@ class DelimitererTest extends TestCase
     public function shouldDelimiterPattern(string $pattern, string $expectedResult)
     {
         // given
-        $delimiterer = new Delimiterer();
+        $delimiterer = new Delimiterer(new DelimiterParser(new FlagsValidator()));
 
         // when
         $result = $delimiterer->delimiter($pattern);
@@ -64,7 +66,7 @@ class DelimitererTest extends TestCase
     public function shouldDelimiterAlreadyDelimitered(string $pattern)
     {
         // given
-        $delimiterer = new Delimiterer();
+        $delimiterer = new Delimiterer(new DelimiterParser(new FlagsValidator()));
 
         // when
         $result = $delimiterer->delimiter($pattern);
@@ -79,7 +81,7 @@ class DelimitererTest extends TestCase
     public function shouldThrowOnNotEnoughDelimiters()
     {
         // given
-        $delimiterer = new Delimiterer();
+        $delimiterer = new Delimiterer(new DelimiterParser(new FlagsValidator()));
 
         // then
         $this->expectException(ExplicitDelimiterRequiredException::class);

--- a/test/Unit/TRegx/CleanRegex/Internal/FlagsValidatorTest.php
+++ b/test/Unit/TRegx/CleanRegex/Internal/FlagsValidatorTest.php
@@ -1,72 +1,65 @@
 <?php
 namespace Test\Unit\TRegx\CleanRegex\Internal;
 
-use TRegx\CleanRegex\Internal\FlagsValidator;
 use PHPUnit\Framework\TestCase;
+use TRegx\CleanRegex\Internal\FlagsValidator;
 
 class FlagsValidatorTest extends TestCase
 {
     /**
      * @test
      */
-    public function shouldAllowFlags()
+    public function shouldBeValid()
     {
         // given
         $flags = new FlagsValidator();
 
         // when
-        $flags->validate('mi');
+        $isValid = $flags->isValid('mi');
 
         // then
-        $this->assertTrue(true);
+        $this->assertTrue($isValid);
     }
 
     /**
      * @test
      */
-    public function shouldEmptyBeAllowed()
+    public function shouldBeValid_empty()
     {
         // given
         $flags = new FlagsValidator();
 
         // when
-        $flags->validate('');
+        $isValid = $flags->isValid('');
 
         // then
-        $this->assertTrue(true);
-    }
-
-    /**
-     * @test
-     * @expectedException \TRegx\CleanRegex\Exception\CleanRegex\FlagNotAllowedException
-     */
-    public function shouldNotAllowWhitespace()
-    {
-        // given
-        $flags = new FlagsValidator();
-
-        // when
-        $flags->validate('g i');
+        $this->assertTrue($isValid);
     }
 
     /**
      * @test
      * @dataProvider invalidFlags
-     * @expectedException \TRegx\CleanRegex\Exception\CleanRegex\FlagNotAllowedException
      * @param string $flag
      */
-    public function shouldNotAllowInvalidFlags(string $flag)
+    public function shouldNotBeValid(string $flag)
     {
         // given
-        $flags = new FlagsValidator();
+        $validator = new FlagsValidator();
 
         // when
-        $flags->validate($flag);
+        $isValid = $validator->isValid($flag);
+
+        // then
+        $this->assertFalse($isValid, "Failed asserting that flags '$flag' is invalid");
     }
 
     public function invalidFlags()
     {
         return [
+            // whitespace
+            ['g g'],
+
+            // flags
             ['+g'],
             ['-g'],
             ['/'],


### PR DESCRIPTION
`PatternSimplifier` can
 - Simplify quantifiers - `{0,1}` -> `?`
 - Change character groups - `[0-9]` -> `\d` (same with `\w`, `\W` and `\D`) regardless of order
 - Change one letter alternation - `(a|b|c)` -> `[abc]`
 - Remove quotes from group `[\.\)]` ->` [.)]`
 - Remove group for one character (escaped if necessary) -> `[?]` -> `\?`