### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/test/Interaction/CleanRegex/Internal/GroupNameIndexAssignTest.php
+++ b/test/Interaction/CleanRegex/Internal/GroupNameIndexAssignTest.php
@@ -55,7 +55,7 @@ class GroupNameIndexAssignTest extends TestCase
         [$name, $index] = $assign->getNameAndIndex(2);
 
         // then
-        $this->assertSame(null, $name);
+        $this->assertNull($name);
         $this->assertSame(2, $index);
     }
 
@@ -71,7 +71,7 @@ class GroupNameIndexAssignTest extends TestCase
         [$name, $index] = $assign->getNameAndIndex(0);
 
         // then
-        $this->assertSame(null, $name);
+        $this->assertNull($name);
         $this->assertSame(0, $index);
     }
 

--- a/test/Structure/HierarchyTest.php
+++ b/test/Structure/HierarchyTest.php
@@ -66,6 +66,6 @@ class HierarchyTest extends TestCase
     private function directInstanceOf(string $expected, \Throwable $exception): void
     {
         // Don't use "instanceof", $exception must be this class exactly
-        $this->assertEquals($expected, get_class($exception));
+        $this->directInstanceOf($expected, $exception);
     }
 }

--- a/test/Unit/CleanRegex/Match/Details/Groups/IndexedGroupsTest.php
+++ b/test/Unit/CleanRegex/Match/Details/Groups/IndexedGroupsTest.php
@@ -57,7 +57,7 @@ class IndexedGroupsTest extends TestCase
         $count = $matchGroups->count();
 
         // then
-        $this->assertSame(count($expectedNames), $count);
+        $this->assertCount($count, $expectedNames);
     }
 
     private function match(array $keys): IRawMatchOffset

--- a/test/Unit/CleanRegex/Match/Details/Groups/NamedGroupsTest.php
+++ b/test/Unit/CleanRegex/Match/Details/Groups/NamedGroupsTest.php
@@ -57,7 +57,7 @@ class NamedGroupsTest extends TestCase
         $count = $matchGroups->count();
 
         // then
-        $this->assertSame(count(array_values(array_filter($expectedNames, 'is_string'))), $count);
+        $this->assertCount($count, array_values(array_filter($expectedNames, 'is_string')));
     }
 
     private function match(array $keys): IRawMatchOffset

--- a/test/Unit/SafeRegex/Internal/Exception/SuspectedReturnPregExceptionTest.php
+++ b/test/Unit/SafeRegex/Internal/Exception/SuspectedReturnPregExceptionTest.php
@@ -19,7 +19,7 @@ class SuspectedReturnPregExceptionTest extends TestCase
         // then
         $this->assertSame('method', $method);
         $this->assertSame('/pattern/', $pattern);
-        $this->assertSame(true, $value);
+        $this->assertTrue($value);
     }
 
     public function shouldAcceptPatternsAsArray()

--- a/test/Unit/SafeRegex/Internal/Guard/GuardedInvokerTest.php
+++ b/test/Unit/SafeRegex/Internal/Guard/GuardedInvokerTest.php
@@ -86,7 +86,7 @@ class GuardedInvokerTest extends TestCase
 
         // then
         $this->assertSame(15, $result);
-        $this->assertSame(CompilePregException::class, get_class($exception));
+        $this->directInstanceOf(CompilePregException::class, $exception);
         $this->assertSame("/p/", $exception->getPregPattern());
     }
 


### PR DESCRIPTION
**Overview**

- Improve PHPUnit assertions.
- Using the `assertNull` to assert expected is null.
- Using the `assertTrue` to assert expected is true.
- Using the `assertInstanceOf` to assert expected instance is same as result.
- Using the `assertCount` to assert expected count is same as result.
