### PR TITLE
Add XDEBUG_MODE=coverage for executing PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_script:
   - mkdir -p build/cov
 
 script:
-  - ./vendor/bin/phpunit --bootstrap helper/bootstrap.php test
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit --bootstrap helper/bootstrap.php test


### PR DESCRIPTION
**Overview**

- Adding the `XDEBUG_MODE=coverage` to fix warning message:

```
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set
```
